### PR TITLE
Prevent HttpWebRequest from caching responses

### DIFF
--- a/IronCow/Rest/RestClient.cs
+++ b/IronCow/Rest/RestClient.cs
@@ -829,6 +829,7 @@ namespace IronCow.Rest
             // Initialise the web request
             HttpWebRequest req = (HttpWebRequest)WebRequest.Create(url);
             req.UserAgent = UserAgent;
+            req.Headers[HttpRequestHeader.IfModifiedSince] = DateTime.UtcNow.ToString();
 
             IAsyncResult res = (IAsyncResult)req.BeginGetResponse((IAsyncResult result) =>
             {


### PR DESCRIPTION
I tracked down why MilkMan wasn't updating correctly: it looks like HttpWebRequest returns a cached response if you request the same URL more than once.  (RTM doesn't put cache-control headers on their response, or I presume HttpWebRequest would respect that.)

For reference, here's the discussion that eventually lead me to figure this out:
https://groups.google.com/forum/#!searchin/rememberthemilk-api/caching/rememberthemilk-api/xwfkqr9I_SQ/-8sm2v12TpAJ

RTM will fail the request if there are any unrecognized querystring parameters, so I couldn't foil the caching by adding a unique parameter.  Eventually I solved it by setting the If-Modified-Since header on the request, as described here:
http://stackoverflow.com/questions/5173052/how-do-you-disable-caching-with-webclient-and-windows-phone-7
